### PR TITLE
Enable campaign orchestrator connect button after selections

### DIFF
--- a/frontend/app/components/campaign-orchestrator/campaign-orchestrator.tsx
+++ b/frontend/app/components/campaign-orchestrator/campaign-orchestrator.tsx
@@ -398,7 +398,11 @@ export function CampaignOrchestrator() {
             <button
               type="button"
               onClick={connect}
-              disabled
+              disabled={
+                status === "connecting" ||
+                selectedSources.length === 0 ||
+                selectedChannels.length === 0
+              }
               className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
             >
               {status === "connected" ? "Reconnect" : "Start streaming"}


### PR DESCRIPTION
## Summary
- update the campaign orchestrator connect button to only disable during connection attempts or when required selections are missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dac917e994832bb0f13f7e3bd7ccfe